### PR TITLE
Toggle all 'skip chromats' buttons at once

### DIFF
--- a/root/ngtemplate/input/sequence/by_products.tt
+++ b/root/ngtemplate/input/sequence/by_products.tt
@@ -3,6 +3,9 @@
         has_js = 1,
     }
 -%]
+[%- BLOCK javascript -%]
+<script type="text/javascript" src="[%- c.uri_for('/') -%]static/javascripts/by_products.js"></script>
+[%- END -%]
 
 <div class="row">
   <div class="col-sm-12">
@@ -47,7 +50,8 @@
                 </div>
             </div>
             <div class="form-group">
-                <label><input type="checkbox" name="prod-[% pcr.id %]-skip_chromats" value="1"> Chromats not required
+                <label><input type="checkbox" name="prod-[% pcr.id %]-skip_chromats" class="skip-chromats" value="1"> Chromats not required</label>
+                <button type="button" class="btn btn-xs btn-default" onclick="return toggleAllChromats()">set all</button>
             </div>
             <div class="form-group">
                 <label for="prod-<% pcr.id %>-sequence-type">Sequence type</label>

--- a/root/ngtemplate/input/sequence/by_products.tt
+++ b/root/ngtemplate/input/sequence/by_products.tt
@@ -50,10 +50,6 @@
                 </div>
             </div>
             <div class="form-group">
-                <label><input type="checkbox" name="prod-[% pcr.id %]-skip_chromats" class="skip-chromats" value="1"> Chromats not required</label>
-                <button type="button" class="btn btn-xs btn-default" onclick="return toggleAllChromats()">set all</button>
-            </div>
-            <div class="form-group">
                 <label for="prod-<% pcr.id %>-sequence-type">Sequence type</label>
                 <select class="form-control" name="prod-<% pcr.id %>-sequence-type" id="prod-<% pcr.id %>-sequence-type">
                     <option value="">unknown</option>
@@ -77,6 +73,13 @@
                         </option>
                     <% END %>
                 </select>
+            </div>
+            <div class="form-group">
+                <label><input type="checkbox" name="prod-[% pcr.id %]-skip_chromats" class="skip-chromats" value="1"> Chromats not required</label>
+                <button type="button" class="btn btn-xs btn-default" onclick="return toggleAllChromats()">set all</button>
+                <p class="help-block">Chromats should be uploaded for all Sanger
+                sequencing. Only omit chromats when adding consensus sequences
+                based on next-generation sequencing.</p>
             </div>
         </div>
         <div class="col-md-6">

--- a/root/ngtemplate/input/sequence/by_products.tt
+++ b/root/ngtemplate/input/sequence/by_products.tt
@@ -76,7 +76,7 @@
             </div>
             <div class="form-group">
                 <label><input type="checkbox" name="prod-[% pcr.id %]-skip_chromats" class="skip-chromats" value="1"> Chromats not required</label>
-                <button type="button" class="btn btn-xs btn-default" onclick="return toggleAllChromats()">set all</button>
+                <button type="button" class="btn btn-xs btn-default skip-chromats-toggle">toggle all</button>
                 <p class="help-block">Chromats should be uploaded for all Sanger
                 sequencing. Only omit chromats when adding consensus sequences
                 based on next-generation sequencing.</p>

--- a/root/static/javascripts/by_products.js
+++ b/root/static/javascripts/by_products.js
@@ -1,0 +1,12 @@
+toggleAllChromats = (function(){
+    var state = false;
+
+    return function() {
+        state = !state;
+        document.querySelectorAll('input.skip-chromats').forEach(function(c) {
+            c.checked = state;
+        })
+
+        return false;
+    }
+})();

--- a/root/static/javascripts/by_products.js
+++ b/root/static/javascripts/by_products.js
@@ -1,7 +1,7 @@
-toggleAllChromats = (function(){
+window.addEventListener("load", function() {
     var state = false;
 
-    return function() {
+    function toggleAllChromats() {
         state = !state;
         document.querySelectorAll('input.skip-chromats').forEach(function(c) {
             c.checked = state;
@@ -9,4 +9,7 @@ toggleAllChromats = (function(){
 
         return false;
     }
-})();
+    document.querySelectorAll('button.skip-chromats-toggle').forEach(function(b) {
+        b.addEventListener("click", toggleAllChromats);
+    });
+});


### PR DESCRIPTION
Fixes #6 

The UX is a bit limited but it lets you globally set/clear all of them, regardless of which ones you've already clicked. I figure the usual course of operations is someone clicks one, then clicks another, then realizes they need to click the other 10 too. There doesn't seem to be any one right behavior for what's happened if one or more has happened already, so this just goes for what I think is the least-bad option.