### PR TITLE
Allow censoring dates for browse-only users (scaled to infection or time in follow-up)

### DIFF
--- a/lib/ViroDB/Result/DistinctSampleSearch.pm
+++ b/lib/ViroDB/Result/DistinctSampleSearch.pm
@@ -186,8 +186,18 @@ __PACKAGE__->add_unique_constraint("distinct_sample_search_sample_id_idx", ["sam
 # Created by DBIx::Class::Schema::Loader v0.07042 @ 2017-09-15 15:28:22
 # DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:u9fDqxKbNCcofXcTn204jw
 
+use strict;
+use warnings;
+use 5.018;
+use Viroverse::DateCensor;
+
 sub as_hash {
     my $self = shift;
+
+    my $patient = $self->result_source->schema->resultset("Patient")
+        ->find($self->get_column('patient_id'));
+    my $censor = Viroverse::DateCensor->new({ patient => $patient, censor => 1, });
+
     return {
         %{ $self->next::method(@_) },
 
@@ -199,6 +209,8 @@ sub as_hash {
         viral_load => defined $self->get_column('viral_load') ?
                                 0+$self->get_column('viral_load') :
                                 undef,
+        relative_date => $censor->represent_date($self->sample_date),
+
     };
 }
 

--- a/lib/ViroDB/Result/Patient.pm
+++ b/lib/ViroDB/Result/Patient.pm
@@ -359,5 +359,30 @@ sub aliases {
     return map { $_->external_patient_id } $self->patient_aliases->all;
 }
 
+=head2 estimated_date_infected
+
+=head2 first_visit
+
+These methods are shims to emulate the interface of L<ViroDB::Result::CohortPatientSummary>,
+to allow L<ViroDB::Result::Patient> records to be used interchangeably with them
+as the reference point used to censor dates.
+
+=cut
+
+
+# columns of the cohort_patient_summary table. This is used
+
+sub estimated_date_infected {
+    my $self = shift;
+    return undef unless $self->infections->has_rows;
+    return $self->infections->first->estimated_date;
+}
+
+sub first_visit {
+    my $self = shift;
+    return undef unless $self->visits->has_rows;
+    return $self->visits->order_by('visit_date')->first->visit_date;
+}
+
 __PACKAGE__->meta->make_immutable;
 1;

--- a/lib/ViroDB/Result/Scientist.pm
+++ b/lib/ViroDB/Result/Scientist.pm
@@ -562,7 +562,15 @@ sub as_hash {
 
         # Add the convenience booleans for the benefit of our JS
         map { $_ => $self->$_ ? JSON->true : JSON->false }
-            qw[ is_supervisor is_admin is_retired can_manage_freezers ]
+            qw[
+                is_supervisor
+                is_admin
+                is_retired
+                can_manage_freezers
+                censor_dates
+                can_browse
+                can_edit
+             ]
     };
 }
 

--- a/lib/ViroDB/Result/Scientist.pm
+++ b/lib/ViroDB/Result/Scientist.pm
@@ -548,6 +548,10 @@ sub is_supervisor { $_[0]->role eq "supervisor" }
 sub is_admin      { $_[0]->role eq "admin" }
 sub is_retired    { $_[0]->role eq "retired" }
 
+# Wrapping this test in a predicate method because the criteria
+# might evolve etc.
+sub censor_dates { $_[0]->role eq "browser" }
+
 sub can_manage_freezers { $_[0]->is_admin || $_[0]->is_supervisor }
 
 sub as_hash {

--- a/lib/ViroDB/Result/Scientist.pm
+++ b/lib/ViroDB/Result/Scientist.pm
@@ -540,6 +540,7 @@ __PACKAGE__->has_many(
 # DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:9GuX/zENmQwnb/oPeU2u+A
 
 use JSON::MaybeXS;
+use Viroverse::config;
 use namespace::autoclean;
 
 sub can_browse    { $_[0]->role ne "retired" }
@@ -548,9 +549,9 @@ sub is_supervisor { $_[0]->role eq "supervisor" }
 sub is_admin      { $_[0]->role eq "admin" }
 sub is_retired    { $_[0]->role eq "retired" }
 
-# Wrapping this test in a predicate method because the criteria
-# might evolve etc.
-sub censor_dates { $_[0]->role eq "browser" }
+sub censor_dates {
+    $Viroverse::config::features->{censor_dates} && $_[0]->role eq "browser"
+}
 
 sub can_manage_freezers { $_[0]->is_admin || $_[0]->is_supervisor }
 

--- a/lib/Viroverse/DateCensor.pm
+++ b/lib/Viroverse/DateCensor.pm
@@ -9,6 +9,7 @@ use Types::Standard qw< :types >;
 use Types::Common::String qw< NonEmptySimpleStr >;
 use Viroverse::Types qw< ViroDBRecord >;
 use Viroverse::Logger qw< :log >;
+use DateTime::Format::Duration;
 use namespace::clean;
 
 has strftime_format => (

--- a/lib/Viroverse/DateCensor.pm
+++ b/lib/Viroverse/DateCensor.pm
@@ -1,0 +1,99 @@
+use strict;
+use warnings;
+use utf8;
+use 5.018;
+
+package Viroverse::DateCensor;
+use Moo;
+use Types::Standard qw< :types >;
+use Types::Common::String qw< NonEmptySimpleStr >;
+use Viroverse::Types qw< ViroDBRecord >;
+use Viroverse::Logger qw< :log >;
+use namespace::clean;
+
+has strftime_format => (
+    is       => 'ro',
+    isa      => NonEmptySimpleStr,
+    required => 1,
+    default  => "%Y-%m-%d",
+);
+
+has relative_unit => (
+    is       => 'ro',
+    isa      => Enum[qw[ days weeks months years ]],
+    required => 1
+);
+
+has censor => (
+    is       => 'ro',
+    isa      => Bool,
+    required => 1,
+);
+
+has patient => (
+    is       => 'ro',
+    isa      => (ViroDBRecord['Patient'] | ViroDBRecord['CohortPatientSummary']),
+    required => 0,
+);
+
+has reference_date => (
+    is => 'ro',
+    isa => InstanceOf['DateTime'],
+    required => 0,
+);
+
+sub BUILD {
+    my ($self, $args) = @_;
+    die "One of patient xor reference_date is required"
+        unless $args->{patient} xor $args->{reference_date};
+}
+
+sub represent_date {
+    my ($self, $date) = @_;
+
+    (InstanceOf['DateTime'])->assert_valid($date);
+
+    return $date->strftime($self->strftime_format)
+        unless $self->censor;
+
+    my ($day_0, $type);
+    if ($self->reference_date) {
+        $day_0 = $self->reference_date;
+        $type = "";
+    } elsif ($self->patient->estimated_date_infected) {
+        $day_0 = $self->patient->estimated_date_infected;
+        $type = "pi";
+    } elsif ($self->patient->first_visit) {
+        $day_0 = $self->patient->first_visit;
+        $type = ""
+    } else {
+        # No basis for constructing any kind of relative date
+        return "n/a";
+    }
+
+    my $duration = $date->subtract_datetime($day_0);
+
+    my $format =
+        $self->relative_unit eq "days"
+            ? sub { DateTime::Format::Duration->new(pattern => "%j")
+                ->format_duration($_[0])."d$type" } :
+        $self->relative_unit eq "weeks"
+            ? sub {
+                DateTime::Format::Duration->new(pattern => "%V")
+                ->format_duration($_[0])."w$type" } :
+        $self->relative_unit eq "months"
+            ? sub {
+                my $months = DateTime::Format::Duration->new(pattern => "%j")
+                    ->format_duration($_[0])/30;
+                return sprintf "%.1fm%s", $months, $type;
+            } :
+        $self->relative_unit eq "years"
+            ? sub {
+                my $years = DateTime::Format::Duration->new(pattern => "%j")
+                    ->format_duration($_[0])/365.25;
+                return sprintf "%.1fy%s", $years, $type;
+            } : die "unreachable";
+    return $format->($duration);
+}
+
+1;

--- a/lib/Viroverse/DateCensor.pm
+++ b/lib/Viroverse/DateCensor.pm
@@ -51,7 +51,8 @@ sub BUILD {
 sub represent_date {
     my ($self, $date) = @_;
 
-    (InstanceOf['DateTime'])->assert_valid($date);
+    return undef unless
+        (InstanceOf['DateTime'])->check($date);
 
     return $date->strftime($self->strftime_format)
         unless $self->censor;

--- a/lib/Viroverse/DateCensor.pm
+++ b/lib/Viroverse/DateCensor.pm
@@ -21,7 +21,8 @@ has strftime_format => (
 has relative_unit => (
     is       => 'ro',
     isa      => Enum[qw[ days weeks months years ]],
-    required => 1
+    required => 1,
+    default  => 'days',
 );
 
 has censor => (

--- a/lib/Viroverse/config.pm
+++ b/lib/Viroverse/config.pm
@@ -54,6 +54,7 @@ our $features = {
     ice_cultures => 0,
     epitopedb => 0,
     isla_sequences => 0,
+    censor_dates => 0,
 };
 
 # Load up our local overrides, if any.

--- a/root/browsetemplate/sum-patient.tt
+++ b/root/browsetemplate/sum-patient.tt
@@ -61,10 +61,12 @@
               <table class="table table-condensed table-bordered">
                 <col style="width: 14em">
                 <tr><th>Member of</th><td>[%- patient.groups.join(', ') -%]</td></tr>
+                [% IF ! scientist.censor_dates %]
                 <tr><th>Best estimate of infection</th><td><% patient.get_prop('estimated_infection_date') | html %></td></tr>
                 <tr><th>Acquisition window</th><td>[% date_range(patient.get_prop('infection_date')) %]</td></tr>
                 <tr><th>Onset of Symptoms</th><td> [% date_range(patient.get_prop('symptom_date')) %]</td></tr>
                 <tr><th>Seroconversion window</th><td>[% date_range(patient.get_prop('seroconversion_date')) %]</td></tr>
+                [% END %]
                 <tr><th>HLA</th><td>[%- patient.get_prop('hla').sort.join(', ') -%]</td></tr>
                 <tr><th>Time to First ART</th><td>[%- IF (!patient.time_to_first_art) -%]
                                                       <em>unknown</em>

--- a/root/ngtemplate/partials/patient-list.tt
+++ b/root/ngtemplate/partials/patient-list.tt
@@ -5,7 +5,9 @@
 <thead class="sticky">
     <tr>
         <th>Subject ID</th>
+        [% IF ! scientist.censor_dates %]
         <th>Est. Date Infected</th>
+        [% END %]
         <th id="cohort-col-first-visit">First visit</th>
         <th id="cohort-col-vl">Viral load history</th>
         <th id="cohort-col-latest-visit">Latest visit</th>
@@ -21,12 +23,17 @@
 </thead>
 <tbody>
     [% FOR patient IN patients %]
+    [% USE Censor = Viroverse::DateCensor({'censor'        => scientist.censor_dates,
+                                           'relative_unit' => 'years',
+                                           'patient'       => patient }) %]
     <tr>
         <td class="text-nowrap">[% link_to_patient(patient) | none%]</td>
+        [% IF ! scientist.censor_dates %]
         <td class="text-nowrap">[% patient.estimated_date_infected.strftime("%Y-%m-%d") %] </td>
-        <td class="text-nowrap">[% patient.first_visit.strftime("%Y-%m-%d") %]</td>
+        [% END %]
+        <td class="text-nowrap">[% Censor.represent_date(patient.first_visit) %]</td>
         <td class="sparkline">[% Sparkline.xy_sparkline(patient.viral_loads_scaled) | none %]</td>
-        <td class="text-nowrap">[% patient.latest_visit.strftime("%Y-%m-%d") %]</td>
+        <td class="text-nowrap">[% Censor.represent_date(patient.latest_visit) %]</td>
         <td class="text-right">
             [%~ IF patient.days_to_first_art.defined ~%]
                 [%~ IF (patient.days_to_first_art >= 365) -%]

--- a/root/ngtemplate/partials/sample-tree.tt
+++ b/root/ngtemplate/partials/sample-tree.tt
@@ -65,7 +65,12 @@
             <span>
               <a href="<% c.uri_for_action("/sample/show", [ node.id ]) %>">
                 <% IF node.visit %>
-                  <% node.tissue_type.name %> from <% node.date.ymd || 'unknown date' %>
+                  <% USE Censor = Viroverse::DateCensor({
+                        'censor'          => scientist.censor_dates
+                        'relative_unit'   => 'years',
+                        'patient'         => sample.patient,
+                        }) %>
+                  <% node.tissue_type.name %> from <% Censor.represent_date(node.date) || 'unknown date' %>
                 <% ELSE %>
                   <% IF node.name %><% node.name %> <% END %><% node.tissue_type.name %>
                 <% END %>

--- a/root/ngtemplate/sample/base.tt
+++ b/root/ngtemplate/sample/base.tt
@@ -16,9 +16,16 @@
             [% END %] is
             [% Inflect.noun(sample.tissue_type.name || 'unknown tissue type').indef_article %]
             <i>[% sample.tissue_type.name || 'unknown tissue type' %]</i>
-            sample obtained on
-            <i>[% sample.date.strftime("%B %e, %Y") || 'an unknown date' %]</i>
+            sample obtained
             [%~ IF sample.visit %]
+              [% scientist.censor_dates ? 'at' : 'on' %]
+              [% USE Censor = Viroverse::DateCensor({
+                'censor'          => scientist.censor_dates
+                'relative_unit'   => 'years',
+                'patient'         => sample.patient,
+                'strftime_format' => "%B %e, %Y"
+              }) %]
+              <i>[% Censor.represent_date(sample.date) || 'an unknown date' %]</i>
                 [% IF sample.visit.visit_number %]
                     (visit <i>[% sample.visit.visit_number %]</i>)
                 [% END %]
@@ -26,6 +33,8 @@
                 <a href="[% c.uri_for_action("/patient/show_by_id", [ sample.patient.id ]) %]">
                     <i>[% sample.patient.name %]</i></a>.
             [%~ ELSIF sample.parent_derivation %]
+                on
+                <i>[% sample.date.strftime("%B %e, %Y") || 'an unknown date' %]</i>
                 [% derivation = sample.parent_derivation %]
                 by
                 <i><a href="[% c.uri_for_action('/derivation/show', [ derivation.id ]) %]">
@@ -37,7 +46,13 @@
                 </a></i>
                 performed by
                 <i>[% derivation.scientist.name %]</i>.
-            [%~ ELSE ~%].
+            [%~ ELSE %]
+                [% IF scientist.censor_dates %]
+                from an unknown source.
+                [% ELSE %]
+                on
+                <i>[% sample.date.strftime("%B %e, %Y") || 'an unknown date' %]</i>
+                [% END %]
             [% END %]
         </p>
         [% content | none %]

--- a/root/ngtemplate/sample/panels/dates.tt
+++ b/root/ngtemplate/sample/panels/dates.tt
@@ -1,3 +1,9 @@
+[% USE Censor = Viroverse::DateCensor({
+    'patient' => sample.patient,
+    'censor'  => scientist.censor_dates,
+    'strftime_format' => '%b %e, %Y',
+    'relative_unit' => 'years'
+    }) %]
 <div class="panel panel-default">
     <div class="panel-heading"><h3 class="panel-title">Dates</h3></div>
     <table class="table table-condensed"><tbody>
@@ -5,7 +11,7 @@
             <tr>
                 <td>Visit
                 [%~ IF sample.visit.visit_number %] (#[% sample.visit.visit_number %])[% END %]</td>
-                <td class="text-right">[% sample.visit.visit_date.strftime("%b %e, %Y") || 'unknown'%]</td>
+                <td class="text-right">[% Censor.represent_date(sample.visit.visit_date) || 'unknown'%]</td>
             </tr>
         [% END %]
         [% IF sample.parent_derivation %]

--- a/root/static/javascripts/angular/vv.ui.sampleSearch.js
+++ b/root/static/javascripts/angular/vv.ui.sampleSearch.js
@@ -12,9 +12,9 @@
     .directive('aliquotsInput', subdirective('aliquots-input', { orientation: '@?' }))
   ;
 
-  directive.$inject = ['$log'];
+  directive.$inject = ['$log', '$window'];
 
-  function directive($log) {
+  function directive($log, $window) {
     return {
       restrict: 'A',
       require: 'facetedSearch',
@@ -35,8 +35,10 @@
         // template.
         ctrl.isCohortSelected    = ctrl.isFacetValueSelected.bind(ctrl, 'cohort');
         ctrl.isProjectSelected   = ctrl.isFacetValueSelected.bind(ctrl, 'project');
-        ctrl.isScientistSelected = ctrl.isFacetValueSelected.bind(ctrl, 'scientist');
+        ctrl.isScientistSelected = ctrl.isFacetValueSelected.bind(ctrl, '');
         ctrl.minAvailableAliquots = minAvailableAliquots;
+
+        ctrl.scientist = $window.viroverse.scientist;
 
         ctrl.init();
       },

--- a/root/static/partials/sample/search/full-page.html
+++ b/root/static/partials/sample/search/full-page.html
@@ -86,7 +86,8 @@
         </td>
         <td><a vv-href="/sample/{{ sample.sample_id }}">{{ sample.patient }}</a></td>
         <td>{{ sample.tissue_type }}</td>
-        <td>{{ sample.sample_date }}</td>
+        <td ng-if="!search.scientist.censor_dates || sample.derivation_protocol_id">{{ sample.sample_date }}</td>
+        <td ng-if="search.scientist.censor_dates && !sample.derivation_protocol_id">{{ sample.relative_date }}</td>
         <td><a vv-href="/sample/{{ sample.sample_id }}">{{ sample.name }}</a></td>
         <td>{{ sample.derivation_protocol }}</td>
         <td class="text-right">

--- a/root/static/partials/sample/search/within-patient.html
+++ b/root/static/partials/sample/search/within-patient.html
@@ -47,7 +47,12 @@
         <tbody>
           <tr ng-repeat="sample in search.result.rows track by sample.sample_id">
             <td><a vv-href="/sample/{{ sample.sample_id }}">{{ sample.sample_id }}</a></td>
-            <td class="text-nowrap">{{ sample.sample_date }}</td>
+            <td class="text-nowrap"
+                ng-if="!search.scientist.censor_dates || sample.derivation_protocol_id"
+                >{{ sample.sample_date }}</td>
+            <td class="text-nowrap"
+                ng-if="search.scientist.censor_dates && !sample.derivation_protocol_id"
+                >{{ sample.relative_date }}</td>
             <td>{{ sample.tissue_type }}</td>
             <td><a vv-href="/sample/{{ sample.sample_id }}">{{ sample.name }}</a></td>
             <td>{{ sample.derivation_protocol }}</td>

--- a/t/date_censor.t
+++ b/t/date_censor.t
@@ -1,0 +1,42 @@
+use 5.010;
+use warnings;
+use strict;
+use ViroDB;
+use Test::More;
+use Viroverse::DateCensor;
+use namespace::clean;
+
+
+sub ymd {
+    my ($y, $m, $d) = @_;
+    return DateTime->new(year => $y, month => $m, day => $d);
+}
+
+my $y2k = ymd(2000, 1, 1);
+
+sub test {
+    my ($date, $do_censor, $repr, $expect) = @_;
+    my $censor = Viroverse::DateCensor->new(
+        censor         => $do_censor,
+        relative_unit  => $repr,
+        reference_date => $y2k,
+    );
+    is($censor->represent_date($date), $expect,
+        sprintf "%s as %s should be %s when %s",
+                $date->strftime("%Y-%m-%d"),
+                $repr,
+                $expect,
+                $do_censor ? 'censored' : 'not_censored');
+}
+
+test(ymd(2000,1, 2), 1, 'days',   '1d');
+test(ymd(2001,1, 1), 1, 'years',  '1.0y');
+test(ymd(2001,1, 1), 1, 'weeks',  '51w'); #NB
+test(ymd(2001,1, 8), 1, 'weeks',  '52w'); #NB
+test(ymd(2001,1, 1), 1, 'months', '12.0m');
+test(ymd(2008,7, 1), 1, 'years',  '8.4y'); #NB
+test(ymd(2008,7, 1), 1, 'months', '102.0m');
+test(ymd(2001,1, 1), 0, 'years',  '2001-01-01');
+
+done_testing;
+


### PR DESCRIPTION
To support alternate instances of Viroverse aimed at outside researchers interested in samples we manage access to, we want to be able to present data without disclosing precise sampling dates, which are sensitive data not for publication outside the research group. We are taking an approach with a couple of layers. This branch represents the cosmetic layer: when the `censor_dates` feature is enabled, users with the `browser` role will see a relative time for most dates based on a subject's clinic visit, scaled to time post infection (when an estimated infection date is known) or scaled to time from the first visit (when it's not). This is an _incomplete_ solution to date privacy, parts of the application will still send absolute dates to the client (namely, the APIs for sample searches, lab graphs, and the patient graphs). For our purposes, we will be ultimately relying on scaling all clinically relevant dates in the database to a single origin date. This way dates that are not censored in this branch will nevertheless not convey any private information.