### PR TITLE
Fix incorrect copy-pasted variable name

### DIFF
--- a/root/ngtemplate/partials/sample-tree.tt
+++ b/root/ngtemplate/partials/sample-tree.tt
@@ -68,7 +68,7 @@
                   <% USE Censor = Viroverse::DateCensor({
                         'censor'          => scientist.censor_dates
                         'relative_unit'   => 'years',
-                        'patient'         => sample.patient,
+                        'patient'         => node.patient,
                         }) %>
                   <% node.tissue_type.name %> from <% Censor.represent_date(node.date) || 'unknown date' %>
                 <% ELSE %>


### PR DESCRIPTION
`sample` was copied from elsewhere, likely not noticed during review due
to only checking the changes to the sample tree component on sample
pages, where a variable named `sample` would've crept into the template
scope from the main page and this worked fortuitously (because TT
INCLUDEs don't clear out the scope from the including page, in general,
I think). On sequence pages though the template's topic is a `sequence`
and the DateCensor constructor threw validation errors. Better than
silently doing something wrong!

Fixes #21 