### PR TITLE
Adopt some suggestions from shellcheck

### DIFF
--- a/scripts/deploy
+++ b/scripts/deploy
@@ -11,7 +11,7 @@ RESET="\033[0m"
 set -o errexit
 set -o nounset
 set -o pipefail
-trap "echo -e '=$FAIL NOT OK - error running previous command!$RESET' >&2" ERR
+trap 'echo -e "=$FAIL NOT OK - error running previous command!$RESET" >&2' ERR
 
 function try() {
     echo -ne "$PS4$TRACE"
@@ -26,30 +26,30 @@ fi
 
 # Setup detailed logging for this entire script
 # In bash 4 it'd be: exec |& tee -a var/log/deploy.details.log
-npipe=`mktemp -t vv-deploy-$$.XXXX`
-rm -f $npipe
-mkfifo $npipe
-trap "rm -f $npipe" EXIT
-tee <$npipe -a $LOGDETAILS &
+npipe=$( mktemp -t vv-deploy-$$.XXXX )
+rm -f "$npipe"
+mkfifo "$npipe"
+trap 'rm -f "$npipe"' EXIT
+tee <"$npipe" -a $LOGDETAILS &
 exec 1>&-
-exec 1>$npipe
+exec 1>"$npipe"
 exec 2>&1
 
 # Are we on a production host?
-host=`hostname -s`
-if grep -qF $host etc/production-hostname; then
+host=$( hostname -s )
+if grep -qF "$host" etc/production-hostname; then
     PRODUCTION=1
 else
     PRODUCTION=0
 fi
 
 # Enough stalling, punch the gas
-start=`date`
-tag=deploy-$host-`date -u +%FT%H%M%SZ`
+start=$( date )
+tag=deploy-$host-$( date -u +%FT%H%M%SZ )
 echo "= Deploying to $host on $start"
 
 # Require a clean git dir
-if [[ -n `git status --porcelain --untracked-files=no` ]]; then
+if [[ -n $( git status --porcelain --untracked-files=no ) ]]; then
     echo "Please commit or stash these uncommitted local changes first."
     echo
     git status
@@ -59,7 +59,7 @@ if [[ -n `git status --porcelain --untracked-files=no` ]]; then
 fi
 
 # Record starting sha
-echo "$start @ `git rev-parse HEAD` " >>$LOG
+echo "$start @ $( git rev-parse HEAD ) " >>$LOG
 
 # Fast-forward to latest master
 try git pull --ff
@@ -73,7 +73,7 @@ if carton exec sqitch status | grep 'Undeployed change' >/dev/null; then
 
     # Create a squitch deploy tag
     if [[ $PRODUCTION -eq 1 ]]; then
-        try carton exec sqitch tag $tag -m "Deployed to $host"
+        try carton exec sqitch tag "$tag" -m "Deployed to $host"
         try git commit schema/sqitch.plan -m "Tag sqitch deploy to $host"
     fi
 fi
@@ -85,7 +85,7 @@ try make etc
 try ./vv scripts/restart-server
 
 if [[ $PRODUCTION -eq 1 ]]; then
-    try git tag -am "Deployed to $host" $tag
+    try git tag -am "Deployed to $host" "$tag"
     try git push --tags origin HEAD
 fi
 

--- a/scripts/introspect-fks
+++ b/scripts/introspect-fks
@@ -13,7 +13,7 @@ table=$1
 column=$2
 [[ $column == "id" ]] && column=${table#*.}_id
 value=$3
-[[ -z $table ]] && echo "usage: `basename $0` [schema.]table [column|'id' [value]]" && exit 1
+[[ -z $table ]] && echo "usage: $( basename "$0" ) [schema.]table [column|'id' [value]]" && exit 1
 
 case "$table" in
     *.*)
@@ -43,7 +43,7 @@ fi
 echo
 echo
 echo "Ctrl-C to cancel, Enter to proceed."
-read
+read -r
 
 if [[ -n $column ]]; then
     column_constraint="= '$column'"

--- a/scripts/restart-server
+++ b/scripts/restart-server
@@ -1,38 +1,38 @@
 #!/bin/bash
-home=`dirname $0`/..
-var=$home/var
-pidfile=$var/run/server-starter.pid
-statusfile=$var/run/server-starter.status
-logfile=$var/log/server.log
+home=$( dirname "$0" )/..
+var="$home/var"
+pidfile="$var/run/server-starter.pid"
+statusfile="$var/run/server-starter.status"
+logfile="$var/log/server.log"
 
-[[ -d $var/run ]] || mkdir -p $var/run
-[[ -d $var/log ]] || mkdir -p $var/log
+[[ -d "$var/run" ]] || mkdir -p "$var/run"
+[[ -d "$var/log" ]] || mkdir -p "$var/log"
 
-cd $home
+cd "$home" || exit 1
 
-if test -s $pidfile && kill -0 `cat $pidfile` 2>/dev/null; then
+if test -s "$pidfile" && kill -0 "$(cat "$pidfile")" 2>/dev/null; then
     echo -n "Re-starting server... "
     start_server \
         --restart \
-        --pid-file=$pidfile \
-        --status-file=$statusfile \
+        --pid-file="$pidfile" \
+        --status-file="$statusfile" \
         && echo "done" || echo "FAILED ($?)"
 else
     echo -n "Starting server... "
     start_server \
         --port=localhost:8080 \
-        --pid-file=$pidfile \
-        --status-file=$statusfile \
+        --pid-file="$pidfile" \
+        --status-file="$statusfile" \
         --interval=10 \
         -- \
-        plackup -s Starlet -E ${PLACK_ENV:-deployment} \
+        plackup -s Starlet -E "${PLACK_ENV:-deployment}" \
             -e 'enable_if { $_[0]->{REMOTE_ADDR} eq "127.0.0.1" }
                     SetEnvFromHeader => REMOTE_USER => "X-Forwarded-REMOTE-USER";
                 enable "ReverseProxy";' \
             --max-workers=10 \
             --timeout=300 \
             app.psgi \
-        >>$logfile 2>&1 &
+        >>"$logfile" 2>&1 &
     ret=$?
     [[ $ret == 0 ]] && echo "done" || echo "FAILED ($ret)"
     echo "Logging to $logfile"

--- a/scripts/restart-server
+++ b/scripts/restart-server
@@ -1,5 +1,5 @@
 #!/bin/bash
-home=$( dirname "$0" )/..
+home=$(dirname "$( dirname "$0" )")
 var="$home/var"
 pidfile="$var/run/server-starter.pid"
 statusfile="$var/run/server-starter.status"

--- a/scripts/stop-server
+++ b/scripts/stop-server
@@ -1,5 +1,5 @@
 #!/bin/bash
-home=$( dirname "$0" )/..
+home=$(dirname "$( dirname "$0" )")
 pidfile=$home/var/run/server-starter.pid
 
 cd "$home" || exit 1

--- a/scripts/stop-server
+++ b/scripts/stop-server
@@ -1,12 +1,12 @@
 #!/bin/bash
-home=`dirname $0`/..
+home=$( dirname "$0" )/..
 pidfile=$home/var/run/server-starter.pid
 
-cd $home
+cd "$home" || exit 1
 
 if [[ -s $pidfile ]]; then
     echo -n "Stopping server... "
-    xargs kill < $pidfile \
+    xargs kill < "$pidfile" \
     && echo "done" || echo "FAILED ($?)"
 else
     echo "No server running (no pid file: $pidfile)"


### PR DESCRIPTION
Mainly quoting and deprecating backticks for `$()`

random maintenance, why not