### PR TITLE
Remove untrue license attestations in source code

### DIFF
--- a/lib/Viroverse/Controller/enum.pm
+++ b/lib/Viroverse/Controller/enum.pm
@@ -334,11 +334,6 @@ sub pool_names : Local {
 
 Brandon Maust
 
-=head1 LICENSE
-
-This library is free software, you can redistribute it and/or modify
-it under the same terms as Perl itself.
-
 =cut
 
 1;

--- a/lib/Viroverse/Controller/input.pm
+++ b/lib/Viroverse/Controller/input.pm
@@ -991,11 +991,6 @@ sub attach_gel_labels : Local {
 
 Wenjie Deng and Brandon Maust
 
-=head1 LICENSE
-
-This library is free software, you can redistribute it and/or modify
-it under the same terms as Perl itself.
-
 =cut
 
 1;

--- a/lib/Viroverse/Controller/need.pm
+++ b/lib/Viroverse/Controller/need.pm
@@ -94,11 +94,6 @@ sub which_package {
 
 Brandon Maust
 
-=head1 LICENSE
-
-This library is free software, you can redistribute it and/or modify
-it under the same terms as Perl itself.
-
 =cut
 
 1;

--- a/lib/Viroverse/Controller/sidebar.pm
+++ b/lib/Viroverse/Controller/sidebar.pm
@@ -350,11 +350,6 @@ sub pcr_more_clear : Local {
 
 Wenjie Deng and Brandon Maust
 
-=head1 LICENSE
-
-This library is free software, you can redistribute it and/or modify
-it under the same terms as Perl itself.
-
 =cut
 
 1;

--- a/lib/Viroverse/Controller/summary.pm
+++ b/lib/Viroverse/Controller/summary.pm
@@ -99,11 +99,6 @@ sub mini : Local {
 
 Brandon Maust
 
-=head1 LICENSE
-
-This library is free software, you can redistribute it and/or modify
-it under the same terms as Perl itself.
-
 =cut
 
 1;

--- a/lib/Viroverse/Model/EpitopeDB.pm
+++ b/lib/Viroverse/Model/EpitopeDB.pm
@@ -33,11 +33,6 @@ L<Catalyst::Model::DBIC::Schema> Model using schema L<EpitopeDB>
 
 Wenjie Deng
 
-=head1 LICENSE
-
-This library is free software, you can redistribute it and/or modify
-it under the same terms as Perl itself.
-
 =cut
 
 1;

--- a/lib/Viroverse/View/JSON.pm
+++ b/lib/Viroverse/View/JSON.pm
@@ -24,11 +24,6 @@ Catalyst View.
 
 Brandon Maust
 
-=head1 LICENSE
-
-This library is free software, you can redistribute it and/or modify
-it under the same terms as Perl itself.
-
 =cut
 
 =head1 METHODS

--- a/lib/Viroverse/View/TT.pm
+++ b/lib/Viroverse/View/TT.pm
@@ -71,11 +71,6 @@ Catalyst TT View.
 
 Brandon Maust
 
-=head1 LICENSE
-
-This library is free software, you can redistribute it and/or modify
-it under the same terms as Perl itself.
-
 =cut
 
 =head1 OVERRIDDEN METHODS

--- a/lib/Viroverse/View/image.pm
+++ b/lib/Viroverse/View/image.pm
@@ -31,11 +31,6 @@ sub process {
 
 Brandon Maust
 
-=head1 LICENSE
-
-This library is free software, you can redistribute it and/or modify
-it under the same terms as Perl itself.
-
 =cut
 
 1;


### PR DESCRIPTION
Viroverse is _not_ available under the same terms as Perl itself.