### PR TITLE
Add simple root redirection logic

### DIFF
--- a/lib/Viroverse/Controller/Homepage.pm
+++ b/lib/Viroverse/Controller/Homepage.pm
@@ -18,12 +18,13 @@ sub base : Chained('/') PathPart('') CaptureArgs(0) { }
 
 sub index : Chained('base') PathPart('') Args(0) {
     my ($self, $c) = @_;
-    my $active     = $c->model("ViroDB::Project")->active;
 
     # If we have configured a root redirection, follow it
     if (Viroverse::Config->conf->{redirect_root_to}) {
-        return $c->response->redirect(Viroverse::Config->conf->{redirect_root_to});
+        return RedirectToUrl($c, Viroverse::Config->conf->{redirect_root_to});
     }
+
+    my $active     = $c->model("ViroDB::Project")->active;
 
     # The extensive prefetching below bundles a bunch of relationships into a
     # single fairly efficient query without resorting to a database view to

--- a/lib/Viroverse/Controller/Homepage.pm
+++ b/lib/Viroverse/Controller/Homepage.pm
@@ -20,6 +20,11 @@ sub index : Chained('base') PathPart('') Args(0) {
     my ($self, $c) = @_;
     my $active     = $c->model("ViroDB::Project")->active;
 
+    # If we have configured a root redirection, follow it
+    if (Viroverse::Config->conf->{redirect_root_to}) {
+        return $c->response->redirect(Viroverse::Config->conf->{redirect_root_to});
+    }
+
     # The extensive prefetching below bundles a bunch of relationships into a
     # single fairly efficient query without resorting to a database view to
     # power the homepage.

--- a/viroverse.conf
+++ b/viroverse.conf
@@ -79,3 +79,6 @@ quality = /usr/local/bin/quality
     isla_sequences = 0
     censor_dates = 0
 </features>
+
+# Redirect the root page to a specific view (e.g. /cohort/1)
+redirect_root_to =


### PR DESCRIPTION
Fixes #48 by adding an optional configuration key, `redirect_root_to`, which provides a URL to redirect `/` to.

Tested by keeping it blank, and also by setting its value to `/cohort/1` and also to a full external URL.