### PR TITLE
Revamp contents of homepage

### DIFF
--- a/lib/Viroverse/Controller/Homepage.pm
+++ b/lib/Viroverse/Controller/Homepage.pm
@@ -24,8 +24,6 @@ sub index : Chained('base') PathPart('') Args(0) {
         return RedirectToUrl($c, Viroverse::Config->conf->{redirect_root_to});
     }
 
-    my $active     = $c->model("ViroDB::Project")->active;
-
     # The extensive prefetching below bundles a bunch of relationships into a
     # single fairly efficient query without resorting to a database view to
     # power the homepage.
@@ -35,7 +33,7 @@ sub index : Chained('base') PathPart('') Args(0) {
     # joining to SamplePatientDate instead of calling a chain of accessors.
     # I assume that'd be better, but I'm not going to try it out now.
     #   -trs, 2 Feb 2018
-    my @assignments = $active
+    my @assignments = $c->model("ViroDB::Project")->active
         ->related_resultset('sample_assignments')
         ->search({ desig_scientist_id => $c->stash->{scientist}->id })
         ->prefetch(
@@ -53,10 +51,10 @@ sub index : Chained('base') PathPart('') Args(0) {
     my $nag = !Viroverse::Config->conf->{registered};
 
     $c->stash(
-        template        => 'homepage/index.tt',
-        active_projects => [ $active->order_by('name')->all ],
-        my_projects     => $my_projects,
-        nag             => $nag,
+        template    => 'homepage/index.tt',
+        my_projects => $my_projects,
+        cohorts     => [ $c->model("ViroDB::Cohort")->order_by('name')->all ],
+        nag         => $nag,
     );
     $c->detach( $c->view("NG") );
 }

--- a/root/ngtemplate/homepage/index.tt
+++ b/root/ngtemplate/homepage/index.tt
@@ -12,8 +12,8 @@
                 Viroverse for!</p>
             </div>
         [% END %]
-        <h2>My Active Samples</h2>
         [% IF my_projects.size > 0 %]
+        <h2>My assigned samples</h2>
             <uib-tabset active="locationHash.value" ng-cloak>
                 [% FOR project IN my_projects.keys.sort %]
                     <uib-tab index="'[% project %]'" heading="[% project %]">
@@ -55,54 +55,13 @@
                     </uib-tab>
                 [% END %]
             </uib-tabset>
-        [% ELSE %]
-            You are not currently assigned to any active samples.
         [% END %]
-
-        <h2>All Active Projects</h2>
-        [% IF active_projects.size > 0 %]
-            <div class="row project-panels">
-                [% FOR active IN active_projects %]
-                    <div class="col-md-2">
-                        <div class="panel panel-info">
-                            <div class="panel-heading panel-title text-center">
-                                <strong>
-                                    <a href="[% c.uri_for_action('/project/show', [ active.project_id ]) %]"
-                                       title="[% active.name %]">
-                                        [%~ active.name ~%]
-                                    </a>
-                                </strong>
-                            </div>
-                            <table class="table table-condensed">
-                                <tbody>
-                                    <tr>
-                                        <td>Samples</td>
-                                        <td class="text-right"><strong>[% $(active.sample_assignments).count | commafy %]</strong></td>
-                                    </tr>
-                                    <tr>
-                                        <td>Sequences</td>
-                                        <td class="text-right"><strong>[% $(active.sequences).count | commafy %]</strong></td>
-                                    </tr>
-                                    <tr>
-                                        <td>DNA</td>
-                                        <td class="text-right"><strong>[% $(active.extractions.dna).count | commafy %]</strong></td>
-                                    </tr>
-                                    <tr>
-                                        <td>RNA</td>
-                                        <td class="text-right"><strong>[% $(active.extractions.rna).count | commafy %]</strong></td>
-                                    </tr>
-                                </tbody>
-                            </table>
-                        </div>
-                    </div>
-                    <% IF loop.count % 6 == 0 %>
-                      <div class="clearfix visible-md-block visible-lg-block"></div>
-                    <% END %>
-                [% END %]
-            </div>
-        [% ELSE %]
-            There are currently no active projects.
+        <h2>Cohorts</h2>
+        <ul class="cohort-list">
+        [% FOREACH cohort IN cohorts %]
+            <li><a href="[% c.uri_for_action("/cohort/show", [cohort.id] ) %]">[% cohort.name %]</a> ([% $(cohort.patient_cohorts).count + 0 %])</li>
         [% END %]
+        </ul>
     </div>
 </div>
 

--- a/root/ngtemplate/project/index.tt
+++ b/root/ngtemplate/project/index.tt
@@ -6,27 +6,49 @@
 <div class="row">
     <div class="col-md-12">
         <h1 class="page-header">Projects</h1>
-    </div>
-    <div class="col-md-8">
-        <h2>Active projects</h2>
-        <table class="table table-condensed">
-            <thead>
-                <tr>
-                    <th>Name</th>
-                    <th>Samples</th>
-                </tr>
-            </thead>
-            <tbody>
-            [% FOR project IN active_projects %]
-                <tr>
-                    <td><a href="[% c.uri_for_action('project/show', [ project.id ] ) %]">[% project.name %]</a></td>
-                    <td>[% $(project.sample_assignments).count %]</td>
-                </tr>
-            [% END %]
-            </tbody>
-        </table>
-    </div>
-    <div class="col-md-4">
+          [% IF active_projects.size > 0 %]
+            <div class="row project-panels">
+                [% FOR active IN active_projects %]
+                    <div class="col-md-2">
+                        <div class="panel panel-info">
+                            <div class="panel-heading panel-title text-center">
+                                <strong>
+                                    <a href="[% c.uri_for_action('/project/show', [ active.project_id ]) %]"
+                                       title="[% active.name %]">
+                                        [%~ active.name ~%]
+                                    </a>
+                                </strong>
+                            </div>
+                            <table class="table table-condensed">
+                                <tbody>
+                                    <tr>
+                                        <td>Samples</td>
+                                        <td class="text-right"><strong>[% $(active.sample_assignments).count | commafy %]</strong></td>
+                                    </tr>
+                                    <tr>
+                                        <td>Sequences</td>
+                                        <td class="text-right"><strong>[% $(active.sequences).count | commafy %]</strong></td>
+                                    </tr>
+                                    <tr>
+                                        <td>DNA</td>
+                                        <td class="text-right"><strong>[% $(active.extractions.dna).count | commafy %]</strong></td>
+                                    </tr>
+                                    <tr>
+                                        <td>RNA</td>
+                                        <td class="text-right"><strong>[% $(active.extractions.rna).count | commafy %]</strong></td>
+                                    </tr>
+                                </tbody>
+                            </table>
+                        </div>
+                    </div>
+                    <% IF loop.count % 6 == 0 %>
+                      <div class="clearfix visible-md-block visible-lg-block"></div>
+                    <% END %>
+                [% END %]
+            </div>
+          [% ELSE %]
+            <p>There are currently no active projects.</p>
+          [% END %]
         <h2>Finished projects</h2>
         <table class="table table-condensed">
             <thead>


### PR DESCRIPTION
The project panels aren't super useful these days, because
project-management functionality is underused and some new users
confused projects with cohorts, causing discoverability issues. Instead
list the cohorts on the homepage, and if a user has no samples assigned
just remove that chunk of content entirely. The project panels are
relocated to the project index.

Fixes #51 