### PR TITLE
Show a "value missing" sigil for missing copy_number.value

### DIFF
--- a/root/ngtemplate/sample/extractions.tt
+++ b/root/ngtemplate/sample/extractions.tt
@@ -49,7 +49,7 @@
                     <ul>
                         [% FOREACH copy_number IN primerset.value %]
                         <li><a href="[% c.uri_for_action('summary/copy_number', copy_number.id) %]">
-                        [% copy_number.value %]
+                        [% defined(copy_number.value) ? copy_number.value : "(value missing)" %]
                         </a> <small>[% copy_number.date_created %]</small></li>
                         [% END %]
                     </ul>


### PR DESCRIPTION
On some extractions with gel images, the copy_number.value field is NULL, which makes the link to the gel invisible. This modifies the template to show a placeholder in that case.