### PR TITLE
Fix execution of quality command-line tool

### DIFF
--- a/lib/Viroverse/Controller/input/pcr.pm
+++ b/lib/Viroverse/Controller/input/pcr.pm
@@ -226,7 +226,8 @@ sub calc_copy_number : Private {
     my $tfh = File::Temp->new(TEMPLATE => 'quality_src.txt-XXXX');
     print $tfh $q_src_txt;
 
-    my $Qresults =  `Viroverse::Config->conf->{quality} $tfh`;
+    my $quality_cmd = Viroverse::Config->conf->{quality};
+    my $Qresults =  `$quality_cmd $tfh`;
 
     my @Qres = split (/Results for/, $Qresults);
     foreach my $res (@Qres){


### PR DESCRIPTION
After revamping the configuration file mechanism, the interpolation of
this shell command became incorrect, and quality would not execute.
Instead we can see this telltale error in the log:

  sh: Viroverse::Config-: command not found

It works now. I spent zero time looking for other ways to improve this
code just now; it should probably do things like checking the shell
command for errors and handling them more sensibly. But a lot of this
should be more sensible than it is.