### PR TITLE
Segregate listing of retired scientists

### DIFF
--- a/root/ngtemplate/admin/scientist/index.tt
+++ b/root/ngtemplate/admin/scientist/index.tt
@@ -10,6 +10,8 @@
 <div class="row">
     <div class="col-md-12">
         <h1 class="page-header">Scientists</h1>
+        <p><a href="[% c.uri_for('/admin/scientist/retired') %]">Retired scientists</a>
+        are listed separately.</p>
         <form action="[% c.uri_for('/admin/scientist/add') %]" method="POST" id="add-scientist" role="form" class="form-inline">
             <table class="table table-condensed table-striped">
                 <thead>
@@ -45,22 +47,8 @@
                         <td class="text-right"><button type="submit" class="btn btn-primary">Add</button></td>
                     </tr>
                     [% FOREACH single_scientist IN scientists %]
-                    <tr>
-                        <td>[% single_scientist.scientist_id %]</td>
-                        <td>[% single_scientist.name %]</td>
-                        <td>[% single_scientist.username %]</td>
-                        <td>[% single_scientist.email %]</td>
-                        <td>[% single_scientist.role %]</td>
-                        <td>
-                        [% FOR group_membership IN single_scientist.group_memberships %]
-                            [% IF group_membership.group.name == single_scientist.name %]
-                            [% ELSE %]
-                                [% group_membership.group.name %]<br>
-                            [% END %]
-                        [% END %]
-                        </td>
-                        <td class="text-nowrap"><a href="[% c.uri_for_action('/admin/scientist/edit_scientist', [ single_scientist.scientist_id ]) %]">Edit Scientist</a></td>
-                    </tr>
+                    [% INCLUDE 'admin/scientist/table-row.tt',
+                        scientist = single_scientist %]
                     [% END %]
               </tbody>
             </table>

--- a/root/ngtemplate/admin/scientist/retired.tt
+++ b/root/ngtemplate/admin/scientist/retired.tt
@@ -1,0 +1,38 @@
+[%- page = {
+        title  = "Scientist",
+        has_js = 0,
+        breadcrumbs     = [
+          [ 'Admin',  c.uri_for_action('/admin/index') ],
+          [ 'Scientists', c.uri_for_action('/admin/scientist/index') ],
+          [ 'Retired' ]
+        ]
+    }
+-%]
+<div class="row">
+    <div class="col-md-12">
+        <h1 class="page-header">Retired scientists</h1>
+        <p>Scientists with this role cannot access any Viroverse pages even
+        if they are authorized (have a <kbd>REMOTE_USER</kbd> set) by the
+        reverse proxying webserver. They also are not listed when doing
+        data entry.</p>
+        <table class="table table-condensed table-striped">
+            <thead>
+               <tr>
+                    <th>ID</th>
+                    <th>Name</th>
+                    <th>Username</th>
+                    <th>Email</th>
+                    <th>Role</th>
+                    <th>Group</th>
+                    <th></th>
+                </tr>
+            </thead>
+            <tbody>
+                [% FOREACH single_scientist IN scientists %]
+                [% INCLUDE 'admin/scientist/table-row.tt',
+                    scientist = single_scientist %]
+                [% END %]
+          </tbody>
+        </table>
+    </div>
+</div>

--- a/root/ngtemplate/admin/scientist/table-row.tt
+++ b/root/ngtemplate/admin/scientist/table-row.tt
@@ -1,0 +1,19 @@
+<tr>
+    <td>[% scientist.scientist_id %]</td>
+    <td>[% scientist.name %]</td>
+    <td>[% scientist.username %]</td>
+    <td>[% scientist.email %]</td>
+    <td>[% scientist.role %]</td>
+    <td>
+        [% FOR group_membership IN scientist.group_memberships %]
+        [% IF group_membership.group.name == scientist.name %]
+        [% ELSE %]
+        [% group_membership.group.name %]<br>
+        [% END %]
+        [% END %]
+    </td>
+    <td class="text-nowrap">
+        <a href="[% c.uri_for_action('/admin/scientist/edit_scientist',
+                                    [ scientist.scientist_id ]) %]"
+            >Edit Scientist</a></td>
+</tr>


### PR DESCRIPTION
In our instance we have more of these than active users, and it makes
administration via these sorta barebones pages unwieldy/harder to
browse. With this change, also adjust how scientists are sorted since we
no longer have to exploit the sort order of the role names to
deemphasize the retired users.