### PR TITLE
Fix the refresh_primer_search() function

### DIFF
--- a/schema/deploy/primer_search_refresh.sql
+++ b/schema/deploy/primer_search_refresh.sql
@@ -1,0 +1,10 @@
+-- Deploy primer_search_refresh
+
+BEGIN;
+
+SET search_path TO viroserve;
+
+DROP INDEX primer_search_primer_id_idx;
+CREATE UNIQUE INDEX primer_search_primer_id_idx ON primer_search USING btree(primer_id);
+
+COMMIT;

--- a/schema/revert/primer_search_refresh.sql
+++ b/schema/revert/primer_search_refresh.sql
@@ -1,0 +1,10 @@
+-- Revert primer_search_refresh
+
+BEGIN;
+
+SET search_path TO viroserve;
+
+DROP INDEX primer_search_primer_id_idx;
+CREATE INDEX primer_search_primer_id_idx ON primer_search USING btree(primer_id);
+
+COMMIT;

--- a/schema/sqitch.plan
+++ b/schema/sqitch.plan
@@ -7,3 +7,4 @@ add-browser-scientist-role 2019-03-19T23:49:16Z vagrant <vagrant@localverse> # A
 retire-delta-schema 2019-04-30T20:54:11Z vagrant <vagrant@localverse> # Rename objects out of the delta schema
 migrate-sequence-notes 2019-05-23T17:39:32Z vagrant <vagrant@localverse> # Migrate sequence notes away from polymorphic notes table
 primer_search 2019-07-24T21:33:58Z vagrant <vagrant@localverse># Add materialized view for faceted primer search
+primer_search_refresh 2019-08-06T16:53:02Z vagrant <vagrant@localverse># Make the materialized view refresh of primer_search work

--- a/schema/verify/primer_search_refresh.sql
+++ b/schema/verify/primer_search_refresh.sql
@@ -1,0 +1,7 @@
+-- Verify primer_search_refresh
+
+BEGIN;
+
+SELECT viroserve.refresh_primer_search();
+
+ROLLBACK;


### PR DESCRIPTION
Fixes #71. Removes the `CONCURRENTLY` modifier, since it wasn't necessary and was the source of the failure.