### PR TITLE
Add genome_region to primer faceted search

### DIFF
--- a/lib/ViroDB/Result/PrimerSearch.pm
+++ b/lib/ViroDB/Result/PrimerSearch.pm
@@ -79,6 +79,11 @@ __PACKAGE__->table("viroserve.primer_search");
   data_type: 'numeric[]'
   is_nullable: 1
 
+=head2 regions
+
+  data_type: 'text[]'
+  is_nullable: 1
+
 =cut
 
 __PACKAGE__->add_columns(
@@ -105,11 +110,27 @@ __PACKAGE__->add_columns(
   { data_type => "text", is_nullable => 1 },
   "positions",
   { data_type => "numeric[]", is_nullable => 1 },
+  "regions",
+  { data_type => "text[]", is_nullable => 1 },
 );
 
+=head1 UNIQUE CONSTRAINTS
 
-# Created by DBIx::Class::Schema::Loader v0.07042 @ 2019-07-24 17:18:42
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:9Sp3y4/5uBGKMCpjItlQdw
+=head2 C<primer_search_primer_id_idx>
+
+=over 4
+
+=item * L</primer_id>
+
+=back
+
+=cut
+
+__PACKAGE__->add_unique_constraint("primer_search_primer_id_idx", ["primer_id"]);
+
+
+# Created by DBIx::Class::Schema::Loader v0.07042 @ 2019-08-06 17:40:34
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:eJKGtSet3VB/THXrRc/fRQ
 
 
 # You can replace this text with custom code or comments, and it will be preserved on regeneration

--- a/lib/ViroDB/ResultSet/PrimerSearch.pm
+++ b/lib/ViroDB/ResultSet/PrimerSearch.pm
@@ -44,9 +44,9 @@ sub orientation {
     return $self->search({ "$me.orientation" => \@_ });
 }
 
-sub position {
+sub region {
     my $self = shift;
-    return $self->search_array_overlaps( positions => @_ );
+    return $self->search_array_overlaps( regions => @_ );
 }
 
 

--- a/lib/Viroverse/Search/Primer.pm
+++ b/lib/Viroverse/Search/Primer.pm
@@ -92,11 +92,11 @@ sub _build_query_fields {
                 label   => "Orientation",
             },
         },
-        position => {
-            method => "position",
+        region => {
+            method => "region",
             facet => {
-                column  => \["unnest(positions)"],
-                label   => "Position",
+                column  => \["unnest(regions)"],
+                label   => "Region",
             }
         },
     };

--- a/root/static/partials/primer/search/full-page.html
+++ b/root/static/partials/primer/search/full-page.html
@@ -14,7 +14,7 @@
       </div>
 
       <div class="facet-col">
-        <facet-widget name="position"></facet-widget>
+        <facet-widget name="region"></facet-widget>
       </div>
     </div>
   </div>
@@ -43,6 +43,7 @@
           <th>Orientation</th>
           <th>Organism</th>
           <th>Positions</th>
+          <th>Regions</th>
           <th>Sequence</th>
           <th>Length</th>
           <th>Download</th>
@@ -54,6 +55,7 @@
           <td>{{ primer.orientation }}</td>
           <td>{{ primer.organism }}</td>
           <td>{{ primer.positions.join(', ') }}</td>
+          <td>{{ primer.regions.join(', ') }}</td>
           <td><code class="sequence">{{ primer.sequence }}</code></td>
           <td class="text-right">{{ primer.sequence.length }} bp</td>
           <td><a vv-href="/primer/{{ primer.primer_id }}/fasta">FASTA</a></td>

--- a/root/static/partials/primer/search/full-page.html
+++ b/root/static/partials/primer/search/full-page.html
@@ -40,7 +40,7 @@
       <thead>
         <tr>
           <th>Name</th>
-          <th>Orientation</th>
+          <th><abbr title="Orientation">&lrarr;</abbr></th>
           <th>Organism</th>
           <th>Positions</th>
           <th>Regions</th>

--- a/schema/deploy/primer_search_region.sql
+++ b/schema/deploy/primer_search_region.sql
@@ -1,0 +1,61 @@
+-- Deploy viroverse-public:primer_search_region to pg
+
+BEGIN;
+
+SET search_path TO viroserve;
+
+DROP FUNCTION viroserve.refresh_primer_search();
+DROP MATERIALIZED VIEW primer_search;
+
+CREATE MATERIALIZED VIEW viroserve.primer_search AS
+SELECT
+    primer.primer_id AS primer_id,
+    primer.name AS name,
+    primer.sequence AS sequence,
+    primer.orientation AS orientation,
+    primer.lab_common AS lab_common,
+    primer.notes AS notes,
+    primer.date_added AS date_added,
+    organism.name AS organism,
+    CASE primer.orientation
+        WHEN 'F' THEN
+            array_agg(DISTINCT primer_position.hxb2_end)
+        ELSE
+            array_agg(DISTINCT primer_position.hxb2_start)
+    END AS positions,
+    array_agg(DISTINCT genome_region.name) AS regions
+FROM primer
+LEFT JOIN organism USING (organism_id)
+LEFT JOIN primer_position USING (primer_id)
+LEFT JOIN genome_region ON (
+    (primer.orientation = 'F'
+        AND genome_region.base_start <= primer_position.hxb2_end
+        AND genome_region.base_end >= primer_position.hxb2_end)
+    OR (primer.orientation = 'R'
+        AND genome_region.base_start <= primer_position.hxb2_start
+        AND genome_region.base_end >= primer_position.hxb2_start))
+GROUP BY primer.primer_id, organism.name
+;
+
+CREATE UNIQUE INDEX primer_search_primer_id_idx   ON primer_search USING btree(primer_id);
+CREATE        INDEX primer_search_name_idx        ON primer_search USING btree(name);
+CREATE        INDEX primer_search_sequence_idx    ON primer_search USING btree(sequence);
+CREATE        INDEX primer_search_orientation_idx ON primer_search USING btree(orientation);
+CREATE        INDEX primer_search_date_added_idx  ON primer_search USING btree(date_added);
+CREATE        INDEX primer_search_organism_idx    ON primer_search USING btree(organism);
+
+CREATE FUNCTION viroserve.refresh_primer_search() RETURNS void
+    LANGUAGE sql SECURITY DEFINER
+    AS $$
+        REFRESH MATERIALIZED VIEW CONCURRENTLY viroserve.primer_search;
+    $$;
+
+GRANT EXECUTE ON FUNCTION viroserve.refresh_primer_search() TO :rw_user;
+REVOKE EXECUTE ON FUNCTION viroserve.refresh_primer_search() FROM PUBLIC;
+
+
+GRANT SELECT ON primer_search TO :ro_user;
+GRANT SELECT ON primer_search TO :rw_user;
+
+
+COMMIT;

--- a/schema/revert/primer_search_region.sql
+++ b/schema/revert/primer_search_region.sql
@@ -1,0 +1,52 @@
+-- Revert viroverse-public:primer_search_region from pg
+
+BEGIN;
+
+SET search_path TO viroserve;
+
+DROP FUNCTION viroserve.refresh_primer_search();
+DROP MATERIALIZED VIEW primer_search;
+
+CREATE MATERIALIZED VIEW viroserve.primer_search AS
+SELECT
+    primer.primer_id AS primer_id,
+    primer.name AS name,
+    primer.sequence AS sequence,
+    primer.orientation AS orientation,
+    primer.lab_common AS lab_common,
+    primer.notes AS notes,
+    primer.date_added AS date_added,
+    organism.name AS organism,
+    CASE primer.orientation
+        WHEN 'F' THEN
+            array_agg(DISTINCT primer_position.hxb2_end)
+        ELSE
+            array_agg(DISTINCT primer_position.hxb2_start)
+    END AS positions
+FROM primer
+LEFT JOIN organism USING (organism_id)
+LEFT JOIN primer_position USING (primer_id)
+GROUP BY primer.primer_id, organism.name
+;
+
+CREATE UNIQUE INDEX primer_search_primer_id_idx   ON primer_search USING btree(primer_id);
+CREATE        INDEX primer_search_name_idx        ON primer_search USING btree(name);
+CREATE        INDEX primer_search_sequence_idx    ON primer_search USING btree(sequence);
+CREATE        INDEX primer_search_orientation_idx ON primer_search USING btree(orientation);
+CREATE        INDEX primer_search_date_added_idx  ON primer_search USING btree(date_added);
+CREATE        INDEX primer_search_organism_idx    ON primer_search USING btree(organism);
+
+CREATE FUNCTION viroserve.refresh_primer_search() RETURNS void
+    LANGUAGE sql SECURITY DEFINER
+    AS $$
+        REFRESH MATERIALIZED VIEW CONCURRENTLY viroserve.primer_search;
+    $$;
+
+GRANT EXECUTE ON FUNCTION viroserve.refresh_primer_search() TO :rw_user;
+REVOKE EXECUTE ON FUNCTION viroserve.refresh_primer_search() FROM PUBLIC;
+
+
+GRANT SELECT ON primer_search TO :ro_user;
+GRANT SELECT ON primer_search TO :rw_user;
+
+COMMIT;

--- a/schema/sqitch.plan
+++ b/schema/sqitch.plan
@@ -8,3 +8,4 @@ retire-delta-schema 2019-04-30T20:54:11Z vagrant <vagrant@localverse> # Rename o
 migrate-sequence-notes 2019-05-23T17:39:32Z vagrant <vagrant@localverse> # Migrate sequence notes away from polymorphic notes table
 primer_search 2019-07-24T21:33:58Z vagrant <vagrant@localverse># Add materialized view for faceted primer search
 primer_search_refresh 2019-08-06T16:53:02Z vagrant <vagrant@localverse># Make the materialized view refresh of primer_search work
+primer_search_region 2019-08-06T23:51:15Z vagrant <vagrant@localverse> # Add genome_region to the primer_search materialized view

--- a/schema/verify/primer_search_region.sql
+++ b/schema/verify/primer_search_region.sql
@@ -1,0 +1,12 @@
+-- Verify viroverse-public:primer_search_region on pg
+
+BEGIN;
+
+SELECT
+    1/pg_catalog.has_table_privilege(:'rw_user', 'viroserve.primer_search', 'SELECT')::int +
+    1/pg_catalog.has_table_privilege(:'ro_user', 'viroserve.primer_search', 'SELECT')::int;
+
+SELECT viroserve.refresh_primer_search();
+
+
+ROLLBACK;


### PR DESCRIPTION
Adds an overlapping regions column to the materialized view, and replaces the "position" search facet with "region"

Fixes #69 

Tested working (including deploy/revert), pending clarification from researchers as to whether this is the correct approach for determining a primer's region