### PR TITLE
Restore the Primer ResultSet

### DIFF
--- a/lib/ViroDB/ResultSet/Primer.pm
+++ b/lib/ViroDB/ResultSet/Primer.pm
@@ -1,0 +1,21 @@
+use strict;
+use warnings;
+use 5.018;
+use utf8;
+
+package ViroDB::ResultSet::Primer;
+use base 'ViroDB::ResultSet';
+
+sub plausible_for {
+    my ($self, $query) = @_;
+    my $me    = $self->current_source_alias;
+    my $where = qq{
+                    regexp_replace(upper($me.name), '[^A-Z0-9]', '', 'g')
+        LIKE '%' || regexp_replace(upper(?),        '[^A-Z0-9]', '', 'g') || '%'
+    };
+
+    return $self->search(\[ $where, $query ])
+        ->order_by(\[ "length(?)::float / length($me.name) desc, $me.name asc", $query ]);
+}
+
+1;


### PR DESCRIPTION
In the form it had before the PrimerSearch branch. This file was copied
and repurposed to be the PrimerSearch resultset, but we still need the
plausible_for search for other purposes.