### PR TITLE
Add MolecularProduct role to ViroDB Extraction

### DIFF
--- a/lib/ViroDB/Result/Extraction.pm
+++ b/lib/ViroDB/Result/Extraction.pm
@@ -388,6 +388,9 @@ use Hash::Merge qw< merge >;
 
 with 'ViroDB::Role::HasCopyNumberSummary';
 
+sub input_product { return $_[0]->sample; }
+with "Viroverse::Model::Role::MolecularProduct";
+
 sub copy_number_summary_of_rts {
     my $self = shift;
     my %merged;


### PR DESCRIPTION
This was missing from the pacbio branch, and it makes getting the input
sample of a PCR product in ViroDB-world not work correctly because
Extraction instances have a sample_id method, but it returns the actual
numeric ID, not a reference to a sample as in CDBI-world.