### PR TITLE
Work-in-progress on ISLA importer

### DIFF
--- a/lib/Viroverse/Import/ISLA.pm
+++ b/lib/Viroverse/Import/ISLA.pm
@@ -1,0 +1,153 @@
+use strict;
+use warnings;
+use utf8;
+use 5.018;
+
+package Viroverse::Import::ISLA;
+use Moo;
+use List::Util qw< any all >;
+use Viroverse::Logger qw< :log :dlog >;
+use Types::Standard -types;
+use Viroverse::Types -types;
+use Types::Common::String qw< SimpleStr NonEmptySimpleStr >;
+use Types::Common::Numeric qw< :types >;
+use ViroDB;
+use Viroverse::CachingFinder;
+use namespace::clean;
+
+with 'Viroverse::Import',
+     'Viroverse::Import::HasCreatingScientist';
+
+=head1 DESCRIPTION
+
+Creates the required records for ISLA PCR from a single sample, including
+positivity of any final round products.
+
+=cut
+
+has sample => (
+    is       => 'ro',
+    isa      => ViroDBRecord["Sample"],
+    coerce   => 1,
+    required => 1,
+);
+
+has extraction_date => (
+    is       => 'ro',
+    isa      => YMD,
+    coerce   => 1,
+    required => 0,
+);
+
+has extraction_cells_used => (
+    is       => 'ro',
+    isa      => PositiveNum,
+    required => 0,
+);
+
+has extraction_concentration => (
+    is       => 'ro',
+    isa      => PositiveNum,
+    required => 0,
+);
+
+has extraction_eluted_volume => (
+    is       => 'ro',
+    isa      => PositiveNum,
+    required => 0,
+);
+
+has extraction => (
+    is       => 'rwp',
+    isa      => ViroDBRecord[Extraction],
+    coerce   => 0,
+    init_arg => undef,
+);
+
+has pcr_input_dna_volume => (
+    is       => 'ro',
+    isa      => PositiveNum,
+    required => 0,
+);
+
+has pcr_round_1_date => (
+    is       => 'ro',
+    isa      => YMD,
+    coerce   => 1,
+    required => 1,
+);
+
+has pcr_round_2_date => (
+    is       => 'ro',
+    isa      => YMD,
+    coerce   => 1,
+    required => 1,
+);
+
+has pcr_round_3_date => (
+    is       => 'ro',
+    isa      => YMD,
+    coerce   => 1,
+    required => 1,
+);
+
+has gel => (
+    is => 'lazy',
+    isa =>
+
+has '+key_map' => (
+    isa => Dict[
+        pcr_nickname   => NonEmptySimpleStr,
+        pos_neg_result => NonEmptySimpleStr,
+    ],
+);
+
+sub BUILD {
+    my ($self, $args) = @_;
+    my @extraction_keys = qw[ extraction_date extraction_eluted_volume
+                              extraction_cells_used extraction_concentration ];
+    if (  any { defined $args->{$_} } @extraction_keys &&
+        ! all { defined $args->{$_} } @extraction_keys) {
+        die "All extraction fields must be provided if creating an extraction";
+    }
+}
+
+sub process_row {
+    my ($self, $row) = @_;
+    state $db = ViroDB->instance;
+    my $units = $db->resultset("Unit");
+
+    # Only one extraction should be created. We do it here instead of with a
+    # 'lazy' attribute and _build_extraction to ensure we don't create bogus
+    # records before opening the transaction where rows will be processed.
+    # If this turns out to be needed in other importers, this should be
+    # refactored into a second hook for the Import role, like
+    # 'before_processing_rows' or 'do_at_start' or something.
+    if ($self->extraction_date && ! $self->extraction) {
+        my $extraction = $self->sample->extractions->create({
+            scientist          => $self->creating_scientist->id,
+            amount             => $self->extraction_cells_used,
+            unit               => $units->find({ name => "10^6 cells" }),
+            eluted_vol         => $self->extraction_eluted_volume,
+            eluted_vol_unit    => $units->find({ name => "ul" }),
+            concentration      => $self->extraction_concentration,
+            conenctration_unit => $units->find({ name => "ng/ul" }),
+        });
+        $extraction->discard_changes;
+        $self->_set_extraction($extraction);
+    }
+
+    my $template = $self->extraction || $self->sample;
+
+    # Linear amplification
+
+    # Binding and extension
+
+    # PCR 1
+
+    # PCR 2
+
+    # PCR 3
+}
+
+1;

--- a/lib/Viroverse/Import/SampleManifest.pm
+++ b/lib/Viroverse/Import/SampleManifest.pm
@@ -9,8 +9,6 @@ use Viroverse::Logger qw< :log :dlog >;
 use Types::Standard -types;
 use Viroverse::Types -types;
 use Types::Common::String qw< SimpleStr NonEmptySimpleStr >;
-use Types::DateTime -all;
-use DateTime::Format::Strptime;
 use ViroDB;
 use namespace::clean;
 
@@ -50,9 +48,7 @@ has '+key_map' => (
 
 has received_date => (
     is => 'ro',
-    isa => DateTime->plus_coercions(
-        Format[DateTime::Format::Strptime->new(pattern => "%Y-%m-%d")]
-    ),
+    isa => YMD,
     coerce => 1,
     required => 1,
 );

--- a/lib/Viroverse/Types.pm
+++ b/lib/Viroverse/Types.pm
@@ -10,10 +10,13 @@ use Type::Library -base, -declare => qw(
     EmptyStr
     ImporterClass
     ExternalReferenceUri
+    YMD
 );
 use Type::Utils -all;
 use Types::Standard -types;
 use Types::Common::String qw< NonEmptySimpleStr >;
+use Types::DateTime -all;
+use DateTime::Format::Strptime;
 use Types::LoadableClass -types;
 use Types::URI qw< Uri >;
 use ViroDB;
@@ -68,4 +71,7 @@ coerce ExternalReferenceUri,
     from Str,
     via { URI->new($_) };
 
+declare YMD, as DateTime->plus_coercions(
+    Format[DateTime::Format::Strptime->new(pattern => "%Y-%m-%d")]
+);
 1;


### PR DESCRIPTION
This is a wip state of an initial effort on an ISLA importer for the
Frenkel lab, pushed in case my time runs out before I'm able to finish
the train of thought I started here.

The general idea is to create an Import class of the existing model,
based on some configured job-global parameters and processing the rows
of a rectangular spreadsheet/CSV file. Then, to support uploading ISLA
worksheet templates, probably wrapping this importer in an alternative
front-end "harness" to the base Import UI/controller. This allows
employing the substantial work done to refine the Import system and
exploit its job-running capabilities while still building a more
purpose-built UI for the Frenkel lab.